### PR TITLE
Configure http method used

### DIFF
--- a/app/controllers/graphiql/rails/editors_controller.rb
+++ b/app/controllers/graphiql/rails/editors_controller.rb
@@ -8,6 +8,11 @@ module GraphiQL
       def graphql_endpoint_path
         params[:graphql_path] || raise(%|You must include `graphql_path: "/my/endpoint"` when mounting GraphiQL::Rails::Engine|)
       end
+
+      helper_method :graphql_endpoint_method
+      def graphql_endpoint_method
+        params[:graphql_method] || "POST"
+      end
     end
   end
 end

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -55,13 +55,22 @@
 
     // Defines a GraphQL fetcher using the fetch API.
     var graphQLEndpoint = "<%= graphql_endpoint_path %>";
+    var graphQLMethod = "<%= graphql_endpoint_method %>";
     function graphQLFetcher(graphQLParams) {
-      return fetch(graphQLEndpoint, {
-        method: 'post',
+      var query = graphQLEndpoint;
+      var params = {
+        method: graphQLMethod,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(graphQLParams),
-        credentials: 'include',
-      }).then(function (response) {
+        credentials: 'include'
+      };
+
+      if (graphQLMethod.toLowerCase() === 'get') {
+        query += "?query=" + graphQLParams.query;
+      } else {
+        params.body = JSON.stringify(graphQLParams);
+      }
+
+      return fetch(query, params).then(function (response) {
         return response.json()
       });
     }

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ end
 
 - `at:` is the path where GraphiQL will be served. You can access GraphiQL by visiting that path in your app.
 - `graphql_path:` is the path to the GraphQL endpoint. GraphiQL will send queries to this path.
+- `graphql_method:` is the HTTP method used to send requests to the endpoint. If you don't define it, `POST` will be used.
 
 ### Configuration
 


### PR DESCRIPTION
With this change we should be able to define a `graphql_method` that will be used to send requests to the graph endpoint.

Closes #2 
