### PR TITLE
Added csrf protection support

### DIFF
--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -64,7 +64,7 @@
         headers: { 'Content-Type': 'application/json' },
         headers: { 'Content-Type': 'application/json',
         <% if GraphiQL::Rails.config.csrf %>
-         'X-CSRF-Token': '<%= form_authenticity_token.to_s %>'
+         'X-CSRF-Token': document.getElementsByName("csrf-token")[0].content
         <% end %>
        },
         body: JSON.stringify(graphQLParams),

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -4,6 +4,9 @@
     <title>GraphiQL</title>
     <%= stylesheet_link_tag("graphiql/rails/application") %>
     <%= javascript_include_tag("graphiql/rails/application") %>
+    <% if GraphiQL::Rails.config.csrf %>
+    <%= csrf_meta_tags %>
+    <% end %>
   </head>
   <body>
     <div id="graphiql-container">
@@ -59,6 +62,11 @@
       return fetch(graphQLEndpoint, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json',
+        <% if GraphiQL::Rails.config.csrf %>
+         'X-CSRF-Token': '<%= form_authenticity_token.to_s %>'
+        <% end %>
+       },
         body: JSON.stringify(graphQLParams),
         credentials: 'include',
       }).then(function (response) {

--- a/lib/graphiql/rails.rb
+++ b/lib/graphiql/rails.rb
@@ -24,7 +24,8 @@ module GraphiQL
 
     self.config = OpenStruct.new({
       query_params: false,
-      initial_query: GraphiQL::Rails::WELCOME_MESSAGE
+      initial_query: GraphiQL::Rails::WELCOME_MESSAGE,
+      csrf: false
     })
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ You can override `GraphiQL::Rails` configs in an initializer (eg, `config/initia
 # These are the default values:
 GraphiQL::Rails.config.query_params = false # if true, the GraphQL query string will be persisted the page's query params.
 GraphiQL::Rails.config.initial_query = GraphiQL::Rails::WELCOME_MESSAGE # This string is presented to a new user
+GraphiQL::Rails.config.csrf = false # if true, CSRF token will added and sent along with POST request to the GraphQL endpoint
 ```
 
 ## To-do


### PR DESCRIPTION
Added config option to enable CSRF headers and to send "csrf-token" in the “X-CSRF-Token” HTTP header when making requests.