### PR TITLE
Add :self as option for graphql_path

### DIFF
--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -54,7 +54,7 @@
     // Defines a GraphQL fetcher using the fetch API.
     var graphQLEndpoint = "<%= graphql_endpoint_path %>";
     function graphQLFetcher(graphQLParams) {
-      return fetch(graphQLEndpoint, {
+      return fetch(graphQLEndpoint || window.location, {
         method: 'post',
         headers: <%= raw JSON.pretty_generate(GraphiQL::Rails.config.resolve_headers(self)) %>,
         body: JSON.stringify(graphQLParams),

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,8 @@ end
 ```
 
 - `at:` is the path where GraphiQL will be served. You can access GraphiQL by visiting that path in your app.
-- `graphql_path:` is the path to the GraphQL endpoint. GraphiQL will send queries to this path.
+- `graphql_path:` is the path to the GraphQL endpoint. GraphiQL will send queries to this path.  
+  Specify an empty string to send queries to the same path that GraphiQL is being served from.
 
 ### Configuration
 

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -21,6 +21,12 @@ module GraphiQL
         assert_match(/application-\w+\.js/, @response.body, "it includes assets")
       end
 
+      test "it throws if graphql_path is not specified" do
+        assert_raises(Exception) do
+          get :show
+        end
+      end
+
       test "it uses initial_query config" do
         GraphiQL::Rails.config.initial_query = "{ customQuery }"
         get :show, graphql_path: "/my/endpoint"


### PR DESCRIPTION
I would like to serve GraphiQL from the same path as my GraphQL endpoint. (GraphiQL is returned for `GET`s, and query results are returned for `POST`s.)

I need this feature, because I'd like to package both GraphQL and GraphiQL into a mountable engine (in a gem), and I won't actually know the full `graphql_path` at the time that my engine's routes are drawn.(It's determined by where my gem's engine is mounted by the Rails app.)

This PR allows use of `:self` to indicate the the GraphQL endpoint is the same URL that GraphiQL loaded from. I've added tests and documentation for this minor change.
