### PR TITLE
Add custom header support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ sudo: false
 cache: bundler
 env: CODECLIMATE_REPO_TOKEN=06fc877a3d350f9e7c2945da8f3ab04ec2d6861001bc89acf2f020de4d520577
 rvm:
-  - "2.2"
-  - "2.1"
+  - "2.2.2"

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -4,9 +4,6 @@
     <title>GraphiQL</title>
     <%= stylesheet_link_tag("graphiql/rails/application") %>
     <%= javascript_include_tag("graphiql/rails/application") %>
-    <% if GraphiQL::Rails.config.csrf %>
-    <%= csrf_meta_tags %>
-    <% end %>
   </head>
   <body>
     <div id="graphiql-container">
@@ -59,11 +56,7 @@
     function graphQLFetcher(graphQLParams) {
       return fetch(graphQLEndpoint, {
         method: 'post',
-        headers: { 'Content-Type': 'application/json',
-          <% if GraphiQL::Rails.config.csrf %>
-           'X-CSRF-Token': document.getElementsByName("csrf-token")[0].content
-          <% end %>
-        },
+        headers: <%= raw JSON.pretty_generate(GraphiQL::Rails.resolve_headers(self)) %>,
         body: JSON.stringify(graphQLParams),
         credentials: 'include',
       }).then(function (response) {

--- a/lib/graphiql/rails.rb
+++ b/lib/graphiql/rails.rb
@@ -18,14 +18,57 @@ require "graphiql/rails/welcome_message"
 
 module GraphiQL
   module Rails
+    class Config
+      attr_accessor :query_params, :initial_query, :headers
+
+      def initialize(query_params:, initial_query:, headers:)
+        @query_params = query_params
+        @initial_query = initial_query
+        @headers = headers
+      end
+
+      def csrf=(active)
+        if active
+          ActiveSupport::Deprecation.warn(%|
+
+csrf option has been deprecated and the X-CSRF-Token header is now sent by default.
+
+Please remove the following line from you initializer:
+
+  GraphiQL::Rails.config = true
+
+|)
+        else
+          ActiveSupport::Deprecation.warn(%|
+
+csrf option has been deprecated and the X-CSRF-Token header is now sent by default.
+
+You must now delete the X-CSRF-Token header explicitly:
+
+  GraphiQL::Rails.config.headers.delete('X-CSRF-Token')
+
+|)
+        end
+      end
+    end
+
     class << self
       attr_accessor :config
     end
 
-    self.config = OpenStruct.new({
+    self.config = Config.new(
       query_params: false,
       initial_query: GraphiQL::Rails::WELCOME_MESSAGE,
-      csrf: false
-    })
+      headers: {
+        'Content-Type' => ->(_) { 'application/json' },
+        'X-CSRF-Token' => ->(context) { context.form_authenticity_token }
+      }
+    )
+
+    def self.resolve_headers(context)
+      config.headers.each_with_object({}) do |(key, value), memo|
+        memo[key] = value.call(context)
+      end
+    end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,18 @@ You can override `GraphiQL::Rails` configs in an initializer (eg, `config/initia
 # These are the default values:
 GraphiQL::Rails.config.query_params = false # if true, the GraphQL query string will be persisted the page's query params.
 GraphiQL::Rails.config.initial_query = GraphiQL::Rails::WELCOME_MESSAGE # This string is presented to a new user
-GraphiQL::Rails.config.csrf = false # if true, CSRF token will added and sent along with POST request to the GraphQL endpoint
+GraphiQL::Rails.config.headers = {
+  'Content-Type' => ->(_) { 'application/json' },
+  'X-CSRF-Token' => ->(context) { context.form_authenticity_token }
+}
+```
+
+Authorization Token:
+
+```ruby
+GraphiQL::Rails.config.headers['Authorization'] = ->(context) do
+  "bearer #{context.cookies['_graphql_token']}"
+end
 ```
 
 ### Development


### PR DESCRIPTION
This allows you to add custom headers such as an authorization header so you can
put graphiql behind a token login such as https://graphql.buildkite.com/explorer