### PR TITLE
Escape double quotes in initial_query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /test/dummy/tmp
 /pkg
 /graphiql_update
+.ruby-version
 Gemfile.lock

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -65,7 +65,7 @@
     }
 
     <% if GraphiQL::Rails.config.initial_query %>
-    var defaultQuery = "<%= GraphiQL::Rails.config.initial_query.gsub(/\n/, "\\n") %>";
+    var defaultQuery = "<%= GraphiQL::Rails.config.initial_query.gsub("\n", '\n').gsub('"', '\"').html_safe %>";
     <% else %>
     var defaultQuery = undefined
     <% end %>

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -26,13 +26,13 @@ module GraphiQL
       end
 
       test "it uses initial_query config" do
-        GraphiQL::Rails.config.initial_query = "{ customQuery }"
+        GraphiQL::Rails.config.initial_query = '{ customQuery(id: "123") }'
         get :show, graphql_params
-        assert_includes(@response.body, "{ customQuery }")
+        assert_includes(@response.body, '"{ customQuery(id: \"123\") }"')
 
         GraphiQL::Rails.config.initial_query = nil
         get :show, graphql_params
-        refute_includes(@response.body, "{ customQuery }")
+        refute_includes(@response.body, '"{ customQuery(id: \"123\") }"')
       end
 
       test "it uses query_params config" do


### PR DESCRIPTION
Hey,

I'm trying to use a basic initial query with variables in it. Something like:

```
query {
  post(id: "UUID") {
    title
  }
}
```

This PR:
* Fixes double quotes in JS string
* Avoids escaping the quotes, so instead of `&quot;` it'll produce `"`