### PR TITLE
Exposing server error in response pane if invalid JSON returned

### DIFF
--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -59,9 +59,15 @@
         headers: <%= raw JSON.pretty_generate(GraphiQL::Rails.config.resolve_headers(self)) %>,
         body: JSON.stringify(graphQLParams),
         credentials: 'include',
-      }).then(function (response) {
-        return response.json()
-      });
+      }).then(function(response) {
+        return response.text();
+      }).then(function(text) {
+        try {
+            return JSON.parse(text);
+        } catch(error) {
+            return error + '\n\n' + text;
+        }
+      })
     }
 
     <% if GraphiQL::Rails.config.initial_query %>


### PR DESCRIPTION
If a server 500s or otherwise fails to return valid JSON, the GraphiQL
interface will simply show the error of trying to parse the response as
JSON. This means that for any meaningful GraphQL development, you have
to keep the network tab open at all times to read the actual server
response.

This replaces `.json()` with `.text()` and `JSON.parse()`. This is a
quick fix without much thought put into it, but I couldn't find a more
obvious way to preserve the JSON parsing error along with the actual
server error. The Response() API is...interesting.