### PR TITLE
Rescope rails dependency for flexibility

### DIFF
--- a/graphiql-rails.gemspec
+++ b/graphiql-rails.gemspec
@@ -18,8 +18,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "readme.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_runtime_dependency "rails"
+  s.add_runtime_dependency "railties"
+  s.add_runtime_dependency "sprockets-rails"
 
+  s.add_development_dependency "rails"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "codeclimate-test-reporter", '~>0.4'
   s.add_development_dependency "minitest", "~> 5"


### PR DESCRIPTION
References #37:  Rails association should be more flexible now.
The runtime dependency on `railties` is required for Engine.

References #13: Having a runtime dependency on `sprockets-rails`
explicitly ensures that sprockets will be available for handling
application.{css,js} requests.