### PR TITLE
show response.status in"The server responded with invalid JSON, this is probably a server-side error"

### DIFF
--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -64,7 +64,7 @@
             return response.json();
         } catch(error) {
             return {
-              "stauts": response.status,
+              "status": response.status,
               "message": "The server responded with invalid JSON, this is probably a server-side error",
               "response": response.text(),
             };

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -60,14 +60,13 @@
         body: JSON.stringify(graphQLParams),
         credentials: 'include',
       }).then(function(response) {
-        return response.text();
-      }).then(function(text) {
         try {
-            return JSON.parse(text);
+            return response.json();
         } catch(error) {
             return {
+              "stauts": response.status,
               "message": "The server responded with invalid JSON, this is probably a server-side error",
-              "response": text,
+              "response": response.text(),
             };
         }
       })


### PR DESCRIPTION
When it occurs from session-expiration, it is confusing because server-side has no bugs.

status is a nice hint, even if we can see it with devtools.