### PR TITLE
Adding logo and title options

### DIFF
--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>GraphiQL</title>
+    <title><%= GraphiQL::Rails.config.title || 'GraphiQL' %></title>
+
     <%= stylesheet_link_tag("graphiql/rails/application") %>
     <%= javascript_include_tag("graphiql/rails/application") %>
   </head>
@@ -81,16 +82,21 @@
 
     // Render <GraphiQL /> into the body.
     ReactDOM.render(
-      React.createElement(GraphiQL, {
-        fetcher: graphQLFetcher,
-        defaultQuery: defaultQuery,
-        <% if GraphiQL::Rails.config.query_params %>
-        query: parameters.query,
-        variables: parameters.variables,
-        onEditQuery: onEditQuery,
-        onEditVariables: onEditVariables
+      React.createElement(GraphiQL,
+        {
+          fetcher: graphQLFetcher,
+          defaultQuery: defaultQuery,
+          <% if GraphiQL::Rails.config.query_params %>
+          query: parameters.query,
+          variables: parameters.variables,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables
+          <% end %>
+        },
+        <% if GraphiQL::Rails.config.logo %>
+        React.createElement(GraphiQL.Logo, {}, "<%= GraphiQL::Rails.config.logo %>")
         <% end %>
-      }),
+      ),
       document.getElementById("graphiql-container")
     );
     </script>

--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -7,7 +7,7 @@ module GraphiQL
       # @return [Hash<String => Proc>] Keys are headers to include in GraphQL requests, values are `->(view_context) { ... }` procs to determin values
       attr_accessor :headers
 
-      attr_accessor :query_params, :initial_query, :csrf
+      attr_accessor :query_params, :initial_query, :csrf, :title, :logo
 
       DEFAULT_HEADERS = {
         'Content-Type' => ->(_) { 'application/json' },
@@ -17,10 +17,12 @@ module GraphiQL
         "X-CSRF-Token" => -> (view_context) { view_context.form_authenticity_token }
       }
 
-      def initialize(query_params: false, initial_query: nil, csrf: true, headers: DEFAULT_HEADERS)
+      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS)
         @query_params = query_params
         @headers = headers.dup
         @initial_query = initial_query
+        @title = title
+        @logo = logo
         @csrf = csrf
       end
 

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,8 @@ You can override `GraphiQL::Rails.config` values in an initializer (eg, `config/
 
 - `query_params` (boolean, default `false`): if `true`, the GraphQL query string will be persisted the page's query params
 - `initial_query` (string, default `nil`): if provided, it will be rendered in the query pane for a visitor's first visit
+- `title` (string, default `nil`): if provided, it will be rendered in the page <title> tag
+- `logo` (string, default `nil`): if provided, it will be the text logo
 - `csrf` (boolean, default `true`): include `X-CSRF-Token` in GraphiQL's HTTP requests
 - `headers` (hash, `String => Proc`): procs to fetch header values for GraphiQL's HTTP requests, in the form `(view_context) -> { ... }`. For example:
 

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -10,6 +10,8 @@ module GraphiQL
       teardown do
         GraphiQL::Rails.config.query_params = false
         GraphiQL::Rails.config.initial_query = nil
+        GraphiQL::Rails.config.title = nil
+        GraphiQL::Rails.config.logo = nil
         GraphiQL::Rails.config.headers = {}
       end
 
@@ -33,6 +35,26 @@ module GraphiQL
         GraphiQL::Rails.config.initial_query = nil
         get :show, graphql_params
         refute_includes(@response.body, '"{ customQuery(id: \"123\") }"')
+      end
+
+      test "it uses title config" do
+        GraphiQL::Rails.config.title = 'Custom Title'
+        get :show, graphql_params
+        assert_includes(@response.body, '<title>Custom Title</title>')
+
+        GraphiQL::Rails.config.title = nil
+        get :show, graphql_params
+        assert_includes(@response.body, '<title>GraphiQL</title>')
+      end
+
+      test "it uses logo config" do
+        GraphiQL::Rails.config.logo = 'Custom Logo'
+        get :show, graphql_params
+        assert_includes(@response.body, 'React.createElement(GraphiQL.Logo, {}, "Custom Logo")')
+
+        GraphiQL::Rails.config.logo = nil
+        get :show, graphql_params
+        refute_includes(@response.body, 'React.createElement(GraphiQL.Logo, {}, "Custom Logo")')
       end
 
       test "it uses query_params config" do


### PR DESCRIPTION
Adds a config option for custom title tag and logo.

Usage:

`config/initializers/graphiql.rb`

```
GraphiQL::Rails.config.title = 'My Custom Title - GraphiQL'
GraphiQL::Rails.config.logo = 'My Instance of GraphiQL'
```

For review @rmosolgo

I'll close https://github.com/rmosolgo/graphiql-rails/pull/47 which only had the title option.

Cheers Team!