### PR TITLE
Move inline javascript to an asset javascript file

### DIFF
--- a/app/assets/javascripts/graphiql/rails/application.js
+++ b/app/assets/javascripts/graphiql/rails/application.js
@@ -2,3 +2,4 @@
 //= require ./react-dom-16.6.0
 //= require ./fetch-0.10.1
 //= require ./graphiql-0.12.0
+//= require ./graphiql_show

--- a/app/assets/javascripts/graphiql/rails/graphiql_show.js
+++ b/app/assets/javascripts/graphiql/rails/graphiql_show.js
@@ -1,0 +1,91 @@
+document.addEventListener("DOMContentLoaded", function(event) {
+  var graphiqlContainer = document.getElementById("graphiql-container");
+  var parameters = {};
+
+  var queryParams = graphiqlContainer.dataset.queryParams;
+
+  if (queryParams === 'true') {
+    // Parse the search string to get url parameters.
+    var search = window.location.search;
+    search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+      try {
+        parameters.variables =
+          JSON.stringify(JSON.parse(parameters.variables), null, 2);
+      } catch (e) {
+        // Do nothing, we want to display the invalid JSON as a string, rather
+        // than present an error.
+      }
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+    function updateURL() {
+      var newSearch = '?' + Object.keys(parameters).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(parameters[key]);
+      }).join('&');
+      history.replaceState(null, null, newSearch);
+    }
+
+  }
+
+
+  // Defines a GraphQL fetcher using the fetch API.
+  var graphQLEndpoint = graphiqlContainer.dataset.graphqlEndpointPath;
+  function graphQLFetcher(graphQLParams) {
+    return fetch(graphQLEndpoint, {
+      method: 'post',
+      headers: JSON.parse(graphiqlContainer.dataset.headers),
+      body: JSON.stringify(graphQLParams),
+      credentials: 'include',
+    }).then(function(response) {
+      try {
+        return response.json();
+      } catch(error) {
+        return {
+          "status": response.status,
+          "message": "The server responded with invalid JSON, this is probably a server-side error",
+          "response": response.text(),
+        };
+      }
+    })
+  }
+
+  var initial_query = graphiqlContainer.dataset.initialQuery;
+
+  if (initial_query) {
+    var defaultQuery = initial_query;
+  } else {
+    var defaultQuery = undefined;
+  }
+
+
+  // Render <GraphiQL /> into the body.
+  var element_props = { fetcher: graphQLFetcher, defaultQuery: defaultQuery };
+
+  if (queryParams === 'true') {
+    queryParams = Object.assign({}, queryParams, { query: parameters.query, variables: parameters.variables, onEditQuery: onEditQuery, onEditVariables: onEditVariables });
+  }
+
+  ReactDOM.render(
+    React.createElement(GraphiQL, element_props,
+      React.createElement(GraphiQL.Logo, {}, graphiqlContainer.dataset.logo)
+    ),
+    document.getElementById("graphiql-container")
+  );
+});

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -7,97 +7,12 @@
     <%= javascript_include_tag("graphiql/rails/application") %>
   </head>
   <body>
-    <div id="graphiql-container">
-      Loading...
-    </div>
-    <script>
-    var parameters = {};
-
-    <% if GraphiQL::Rails.config.query_params %>
-    // Parse the search string to get url parameters.
-    var search = window.location.search;
-    search.substr(1).split('&').forEach(function (entry) {
-     var eq = entry.indexOf('=');
-     if (eq >= 0) {
-       parameters[decodeURIComponent(entry.slice(0, eq))] =
-         decodeURIComponent(entry.slice(eq + 1));
-     }
-    });
-    // if variables was provided, try to format it.
-    if (parameters.variables) {
-     try {
-       parameters.variables =
-         JSON.stringify(JSON.parse(parameters.variables), null, 2);
-     } catch (e) {
-       // Do nothing, we want to display the invalid JSON as a string, rather
-       // than present an error.
-     }
-    }
-    // When the query and variables string is edited, update the URL bar so
-    // that it can be easily shared
-    function onEditQuery(newQuery) {
-     parameters.query = newQuery;
-     updateURL();
-    }
-    function onEditVariables(newVariables) {
-     parameters.variables = newVariables;
-     updateURL();
-    }
-    function updateURL() {
-     var newSearch = '?' + Object.keys(parameters).map(function (key) {
-       return encodeURIComponent(key) + '=' +
-         encodeURIComponent(parameters[key]);
-     }).join('&');
-     history.replaceState(null, null, newSearch);
-    }
-    <% end %>
-
-    // Defines a GraphQL fetcher using the fetch API.
-    var graphQLEndpoint = "<%= graphql_endpoint_path %>";
-    function graphQLFetcher(graphQLParams) {
-      return fetch(graphQLEndpoint, {
-        method: 'post',
-        headers: <%= raw JSON.pretty_generate(GraphiQL::Rails.config.resolve_headers(self)) %>,
-        body: JSON.stringify(graphQLParams),
-        credentials: 'include',
-      }).then(function(response) {
-        try {
-            return response.json();
-        } catch(error) {
-            return {
-              "status": response.status,
-              "message": "The server responded with invalid JSON, this is probably a server-side error",
-              "response": response.text(),
-            };
-        }
-      })
-    }
-
-    <% if GraphiQL::Rails.config.initial_query %>
-    var defaultQuery = "<%= GraphiQL::Rails.config.initial_query.gsub("\n", '\n').gsub('"', '\"').html_safe %>";
-    <% else %>
-    var defaultQuery = undefined
-    <% end %>
-
-    // Render <GraphiQL /> into the body.
-    ReactDOM.render(
-      React.createElement(GraphiQL,
-        {
-          fetcher: graphQLFetcher,
-          defaultQuery: defaultQuery,
-          <% if GraphiQL::Rails.config.query_params %>
-          query: parameters.query,
-          variables: parameters.variables,
-          onEditQuery: onEditQuery,
-          onEditVariables: onEditVariables
-          <% end %>
-        },
-        <% if GraphiQL::Rails.config.logo %>
-        React.createElement(GraphiQL.Logo, {}, "<%= GraphiQL::Rails.config.logo %>")
-        <% end %>
-      ),
-      document.getElementById("graphiql-container")
-    );
-    </script>
+    <%= content_tag :div, 'Loading...', id: 'graphiql-container', data: {
+      graphql_endpoint_path: graphql_endpoint_path,
+      initial_query: GraphiQL::Rails.config.initial_query,
+      logo: GraphiQL::Rails.config.logo,
+      headers: GraphiQL::Rails.config.resolve_headers(self),
+      query_params: GraphiQL::Rails.config.query_params
+    } %>
   </body>
 </html>

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 module GraphiQL
   module Rails
@@ -16,28 +16,27 @@ module GraphiQL
       end
 
       def graphql_params
-        { params: { graphql_path: "/my/endpoint" } }
+        { params: { graphql_path: '/my/endpoint' } }
       end
 
-      test "renders GraphiQL" do
+      test 'renders GraphiQL' do
         get :show, graphql_params
         assert_response(:success)
-        assert_includes(@response.body, "React.createElement(GraphiQL", "it renders GraphiQL")
-        assert_includes(@response.body, "my/endpoint", "it uses the provided path")
-        assert_match(/application-\w+\.js/, @response.body, "it includes assets")
+        assert_includes(@response.body, 'my/endpoint', 'it uses the provided path')
+        assert_match(/application-\w+\.js/, @response.body, 'it includes assets')
       end
 
-      test "it uses initial_query config" do
+      test 'it uses initial_query config' do
         GraphiQL::Rails.config.initial_query = '{ customQuery(id: "123") }'
         get :show, graphql_params
-        assert_includes(@response.body, '"{ customQuery(id: \"123\") }"')
+        assert_includes(@response.body, '"{ customQuery(id: &quot;123&quot;) }"')
 
         GraphiQL::Rails.config.initial_query = nil
         get :show, graphql_params
-        refute_includes(@response.body, '"{ customQuery(id: \"123\") }"')
+        refute_includes(@response.body, '"{ customQuery(id: &quot;123&quot;) }"')
       end
 
-      test "it uses title config" do
+      test 'it uses title config' do
         GraphiQL::Rails.config.title = 'Custom Title'
         get :show, graphql_params
         assert_includes(@response.body, '<title>Custom Title</title>')
@@ -47,30 +46,30 @@ module GraphiQL
         assert_includes(@response.body, '<title>GraphiQL</title>')
       end
 
-      test "it uses logo config" do
+      test 'it uses logo config' do
         GraphiQL::Rails.config.logo = 'Custom Logo'
         get :show, graphql_params
-        assert_includes(@response.body, 'React.createElement(GraphiQL.Logo, {}, "Custom Logo")')
+        assert_includes(@response.body, %(data-logo="Custom Logo"))
 
         GraphiQL::Rails.config.logo = nil
         get :show, graphql_params
-        refute_includes(@response.body, 'React.createElement(GraphiQL.Logo, {}, "Custom Logo")')
+        refute_includes(@response.body, %(data-logo="Custom Logo"))
       end
 
-      test "it uses query_params config" do
+      test 'it uses query_params config' do
         get :show, graphql_params
-        refute_includes(@response.body, "onEditQuery")
+        assert_includes(@response.body, %(data-query-params="false"))
 
         GraphiQL::Rails.config.query_params = true
         get :show, graphql_params
-        assert_includes(@response.body, "onEditQuery")
+        assert_includes(@response.body, %(data-query-params="true"))
       end
 
-      test "it renders headers" do
-        GraphiQL::Rails.config.headers["Nonsense-Header"] = -> (view_ctx) { "Value" }
+      test 'it renders headers' do
+        GraphiQL::Rails.config.headers['Nonsense-Header'] = ->(_view_ctx) { 'Value' }
         get :show, graphql_params
-        assert_includes(@response.body, %|"Nonsense-Header": "Value"|)
-        assert_includes(@response.body, %|"X-CSRF-Token": "|)
+        assert_includes(@response.body, %(&quot;Nonsense-Header&quot;:&quot;Value&quot;))
+        assert_includes(@response.body, %(&quot;X-CSRF-Token&quot;:&quot;))
       end
     end
   end


### PR DESCRIPTION
## Problem:
Currently if you are using a CSP and you are blocking `unsafe-inline` for script-src, graphiql won't load due to the inline script tag being blocked in `editors_controller#show`

![image](https://user-images.githubusercontent.com/13983801/51210366-9ef35980-18e0-11e9-9fa1-a5d33e7b0bd1.png)

## Solution:
Move the inline javascript tag to a file and pass all the data through a data attribute

Closes #23 