### PR TITLE
Require sprockets/railtie by default

### DIFF
--- a/lib/graphiql/rails.rb
+++ b/lib/graphiql/rails.rb
@@ -14,6 +14,7 @@ end
 require "graphiql/rails/config"
 require "graphiql/rails/engine"
 require "graphiql/rails/version"
+require "sprockets/railtie"
 
 module GraphiQL
   module Rails


### PR DESCRIPTION
Using this gem forces the app to add a require for `sprockets/railtie`.

Not all rails app needs this. For instance, a Rails app generated in API Only mode.

If this gem needs `sprockets/railtie` to work, it probably make sense to require it as well. 