### PR TITLE
CSS change to allow easier integration into existing Rails stack

### DIFF
--- a/app/assets/stylesheets/graphiql/rails/application.css
+++ b/app/assets/stylesheets/graphiql/rails/application.css
@@ -2,7 +2,7 @@
  = require ./graphiql-0.12.0
 */
 
-#graphiql-rails html,
+html#graphiql-rails,
 #graphiql-rails body,
 #graphiql-container {
   height: 100%;

--- a/app/assets/stylesheets/graphiql/rails/application.css
+++ b/app/assets/stylesheets/graphiql/rails/application.css
@@ -2,7 +2,9 @@
  = require ./graphiql-0.12.0
 */
 
-html, body, #graphiql-container {
+#graphiql-rails html,
+#graphiql-rails body,
+#graphiql-container {
   height: 100%;
   margin: 0;
   overflow: hidden;

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html id="graphiql-rails">
   <head>
     <title><%= GraphiQL::Rails.config.title || 'GraphiQL' %></title>
 


### PR DESCRIPTION
* Adds CSS id `graphiql-rails` to `html` tag
* Includes the id in the `html` and `body` css rules.

With these changes, I'm able to require your CSS / JS base `application` files without effectively altering my host app's `html` and `body` rules.  I'm doing that so I can embed GraphiQL in my existing stack with authentication, look-n-feel etc.

As I'm using it | When used normally (nothing changes)
---------------|--------------------
<img width="1364" alt="Screen Shot 2019-12-20 at 10 05 58 AM" src="https://user-images.githubusercontent.com/382216/71268422-8b334d00-2312-11ea-8779-ee6dba1a770b.png"> | <img width="1364" alt="Screen Shot 2019-12-20 at 10 07 00 AM" src="https://user-images.githubusercontent.com/382216/71268426-8cfd1080-2312-11ea-86f1-ac8877ff0ebd.png">


To do this I copied in two files making changes to use our layout.
* `/controllers/graphiql/rails/editors_controller.rb`
* `/views/graphiql/rails/editors/show.html.erb`


### Host application.css
```css
 *= require graphiql/rails/application
```

### Host application.js
```
//= require graphiql/rails/application
```

# TLDR;
* To avoid requiring versioned CSS files that will cause headaches with graphiql-rails updates, I added a CSS id to increase specificity.
