### PR TITLE
Add instructions for using graphiql in Rails 6 API.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,8 @@ end
 - `graphql_path:` is the path to the GraphQL endpoint. GraphiQL will send queries to this path.
 
 #### Note on API Mode
-If you're using Rails 5 in "API mode", you'll also need to add `require "sprockets/railtie"` to your `application.rb`.
-If using Rails 6 in API mode, after adding `require "sprockets/railtie"`to your `application.rb`, you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets', '~> 3'`. Then run `bundle update` .
+If you're using Rails 5 in "API mode", you'll also need to add `require "sprockets/railtie"` to your `application.rb`.\
+If using Rails 6 in API mode, after adding `require "sprockets/railtie"` to your `application.rb` , you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets', '~> 3'`. Then run `bundle update` .
 
 ### Configuration
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ end
 
 #### Note on API Mode
 If you're using Rails 5 in "API mode", you'll also need to add `require "sprockets/railtie"` to your `application.rb`.\
-If using Rails 6 in API mode, after adding `require "sprockets/railtie"` to your `application.rb` , you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets'`. Then run `bundle install` .
+If using Rails 6 in API mode, after adding `require "sprockets/railtie"` to your `application.rb` , you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets', '~> 3'`. Then run `bundle update` .
 
 ### Configuration
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ end
 
 #### Note on API Mode
 If you're using Rails 5 in "API mode", you'll also need to add `require "sprockets/railtie"` to your `application.rb`.
+If using Rails 6 in API mode, after adding `require "sprockets/railtie"`to your `application.rb`, you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets', '~> 3'`. Then run `bundle update` .
 
 ### Configuration
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ end
 
 #### Note on API Mode
 If you're using Rails 5 in "API mode", you'll also need to add `require "sprockets/railtie"` to your `application.rb`.\
-If using Rails 6 in API mode, after adding `require "sprockets/railtie"` to your `application.rb` , you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets', '~> 3'`. Then run `bundle update` .
+If using Rails 6 in API mode, after adding `require "sprockets/railtie"` to your `application.rb` , you would also need to add the sprockets gem to your Gemfile. `gem 'sprockets'`. Then run `bundle install` .
 
 ### Configuration
 


### PR DESCRIPTION
I added instructions on how to use graphiql inside Rails 6 when in API mode. Simply uncommenting `require sprockets` like in Rails 5 will not work as the user will get back an error asking for a manifest.js file. 