### PR TITLE
Make queryParams work

### DIFF
--- a/app/assets/javascripts/graphiql/rails/graphiql_show.js
+++ b/app/assets/javascripts/graphiql/rails/graphiql_show.js
@@ -4,6 +4,22 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
   var queryParams = graphiqlContainer.dataset.queryParams;
 
+  function onEditQuery(newQuery) {
+    parameters.query = newQuery;
+    updateURL();
+  }
+  function onEditVariables(newVariables) {
+    parameters.variables = newVariables;
+    updateURL();
+  }
+  function updateURL() {
+    var newSearch = '?' + Object.keys(parameters).map(function (key) {
+      return encodeURIComponent(key) + '=' +
+        encodeURIComponent(parameters[key]);
+    }).join('&');
+    history.replaceState(null, null, newSearch);
+  }
+
   if (queryParams === 'true') {
     // Parse the search string to get url parameters.
     var search = window.location.search;
@@ -26,22 +42,6 @@ document.addEventListener("DOMContentLoaded", function(event) {
     }
     // When the query and variables string is edited, update the URL bar so
     // that it can be easily shared
-    function onEditQuery(newQuery) {
-      parameters.query = newQuery;
-      updateURL();
-    }
-    function onEditVariables(newVariables) {
-      parameters.variables = newVariables;
-      updateURL();
-    }
-    function updateURL() {
-      var newSearch = '?' + Object.keys(parameters).map(function (key) {
-        return encodeURIComponent(key) + '=' +
-          encodeURIComponent(parameters[key]);
-      }).join('&');
-      history.replaceState(null, null, newSearch);
-    }
-
   }
 
 
@@ -76,14 +76,15 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
 
   // Render <GraphiQL /> into the body.
-  var element_props = { fetcher: graphQLFetcher, defaultQuery: defaultQuery };
-
+  var elementProps = { fetcher: graphQLFetcher, defaultQuery: defaultQuery, };
+  
+  Object.assign(elementProps, { query: parameters.query, variables: parameters.variables })
   if (queryParams === 'true') {
-    queryParams = Object.assign({}, queryParams, { query: parameters.query, variables: parameters.variables, onEditQuery: onEditQuery, onEditVariables: onEditVariables });
+    Object.assign(elementProps, { onEditQuery: onEditQuery, onEditVariables: onEditVariables });
   }
 
   ReactDOM.render(
-    React.createElement(GraphiQL, element_props,
+    React.createElement(GraphiQL, elementProps,
       React.createElement(GraphiQL.Logo, {}, graphiqlContainer.dataset.logo)
     ),
     document.getElementById("graphiql-container")


### PR DESCRIPTION
This change makes two things:
* fixes #70
* allows to set custom initial query via url params, lieke this `/graphiql?query=MY_QUERY`