### PR TITLE
Remove `Gem::Specification#test_files=` to reduce gem package size

### DIFF
--- a/graphiql-rails.gemspec
+++ b/graphiql-rails.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0' # bc optional keyword args
 
   s.files = Dir["{app,config,lib}/**/*"]
-  s.test_files = Dir["test/**/*"]
 
   s.add_runtime_dependency "railties"
   s.add_runtime_dependency "sprockets-rails"


### PR DESCRIPTION
`Gem::Specification#test_files=` is no longer recommended.
https://github.com/rubygems/guides/issues/90

And it increases gem package size because the option adds test files to
the package.

So I think we should avoid using `test_files=` option.

---

It reduces 4.7MB package size on my local.

before

```bash
$ du graphiql-rails-1.7.0/ --summarize
6.7M    graphiql-rails-1.7.0/
```

after

```bash
$ du graphiql-rails-1.7.0/ --summarize
2.0M    graphiql-rails-1.7.0/
```