### PR TITLE
Allow the `header_editor_enabled` config to be set from the initializer

### DIFF
--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -17,13 +17,14 @@ module GraphiQL
         "X-CSRF-Token" => -> (view_context) { view_context.form_authenticity_token }
       }
 
-      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS)
+      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS, header_editor_enabled: false)
         @query_params = query_params
         @headers = headers.dup
         @initial_query = initial_query
         @title = title
         @logo = logo
         @csrf = csrf
+        @header_editor_enabled = header_editor_enabled
       end
 
       # Call defined procs, add CSRF token if specified


### PR DESCRIPTION
I am running on rails 6 using version 1.8 of the gem. 

When I followed the `readme` and added an initializer at `config/initializers/graphiql.rb` with just one line `GraphiQL::Rails.config.header_editor_enabled = true` my rails app through the following error:

```
undefined method `header_editor_enabled=' for #<GraphiQL::Rails::Config:0x00007f99805d3380> (NoMethodError)
```

By simply allowing the new `header_editor_enabled` parameter to be passed to the initializer, the config can now be set on boot.