### PR TITLE
Remove sprockets

### DIFF
--- a/app/assets/javascripts/graphiql/rails/application.js
+++ b/app/assets/javascripts/graphiql/rails/application.js
@@ -1,5 +1,0 @@
-//= require ./react-16.14.0
-//= require ./react-dom-16.14.0
-//= require ./fetch-0.10.1
-//= require ./graphiql-1.4.2
-//= require ./graphiql_show

--- a/app/assets/stylesheets/graphiql/rails/application.css
+++ b/app/assets/stylesheets/graphiql/rails/application.css
@@ -1,7 +1,3 @@
-/*
- = require ./graphiql-1.4.2
-*/
-
 html, body, #graphiql-container {
   height: 100%;
   margin: 0;

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -3,8 +3,13 @@
   <head>
     <title><%= GraphiQL::Rails.config.title || 'GraphiQL' %></title>
 
+    <%= stylesheet_link_tag("graphiql/rails/graphiql-1.4.2") %>
     <%= stylesheet_link_tag("graphiql/rails/application") %>
-    <%= javascript_include_tag("graphiql/rails/application", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/react-16.14.0", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/react-dom-16.14.0", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/fetch-0.10.1", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/graphiql-1.4.2", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/graphiql_show", nonce: true )  %>
   </head>
   <body>
     <%= content_tag :div, 'Loading...', id: 'graphiql-container', data: {

--- a/graphiql-rails.gemspec
+++ b/graphiql-rails.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "railties"
-  s.add_runtime_dependency "sprockets-rails"
 
   s.add_development_dependency "rails"
   s.add_development_dependency "sqlite3"

--- a/readme.md
+++ b/readme.md
@@ -31,27 +31,6 @@ end
 - `at:` is the path where GraphiQL will be served. You can access GraphiQL by visiting that path in your app.
 - `graphql_path:` is the path to the GraphQL endpoint. GraphiQL will send queries to this path.
 
-#### Note on API Mode
-
-If you're using Rails 6 in "API mode", you'll also need to do the following:
-
-1. Add `require "sprockets/railtie"` to your `application.rb`.
-
-2. Create an `app/assets/config/manifest.js` file and add the following:
-
-```
-//= link graphiql/rails/application.css
-//= link graphiql/rails/application.js
-```
-
-Additionally, for Rails 6, you'll also need to add `sass-rails` gem to your Gemfile and add a `manifest.js` file for Sprockets 4 to work:
-```
---- add to `app/assets/config/manifest.js`
-//= link graphiql/rails/application.css
-//= link graphiql/rails/application.js
-```
-See more details in [issue #13](https://github.com/rmosolgo/graphiql-rails/issues/13#issuecomment-640366886)
-
 ### Configuration
 
 You can override `GraphiQL::Rails.config` values in an initializer (eg, `config/initializers/graphiql.rb`). The configs are:

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -2,7 +2,6 @@ require File.expand_path('../boot', __FILE__)
 
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
**Summary**
Removed all references to sprockets content and moved the CSS and JS calls to the SHOW view in the order defined in the original manifests. 

**Reason**
Sprockets is going away. This gem will not work with an ESBUILD based, rails 7 app. 

- I followed the README instructions as outlined and on several blog posts. They all said the same thing, create your rails app, add the gems, add the sprocket reference, and you should have magic. However, this didn't happen with Rails 7. It isn't as plug-and-play as expected if you exclude sprockets from your setup. 
- Sprockets loads the css and manefest.js files, but doesn't actually compile/include the code it supposed to link to, it merely shows the `require` lines of code in the JS file. When you open the browser devtools to look at the manifest.js resource, you see the following:

```ruby
//= require ./graphiql/js/react-16.14.0
//= require ./graphiql/js/react-dom-16.14.0
//= require ./graphiql/js/fetch-0.10.1
//= require ./graphiql/js/graphiql-1.4.2
//= require ./graphiql/js/graphiql_show
```

What you should see is a compilation of each file into the one manifest. However, sprockets is effectively neutered (turned off) with Rails 7. It doesn't work. 

**Solution**

1. Remove sprockets since it doesnt do anything. 
2. Move all file references to the view.
