### PR TITLE
add inputValueDeprecation flag to be able to introspect deprecated arguments

### DIFF
--- a/app/assets/javascripts/graphiql/rails/graphiql_show.js
+++ b/app/assets/javascripts/graphiql/rails/graphiql_show.js
@@ -77,7 +77,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
 
   // Render <GraphiQL /> into the body.
-  var elementProps = { fetcher: graphQLFetcher, defaultQuery: defaultQuery, headerEditorEnabled: graphiqlContainer.dataset.headerEditorEnabled === 'true' };
+  var elementProps = {
+    fetcher: graphQLFetcher,
+    defaultQuery: defaultQuery,
+    headerEditorEnabled: graphiqlContainer.dataset.headerEditorEnabled === 'true',
+    inputValueDeprecation: graphiqlContainer.dataset.inputValueDeprecation === 'true',
+  };
   
   Object.assign(elementProps, { query: parameters.query, variables: parameters.variables })
   if (queryParams === 'true') {

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -13,7 +13,8 @@
       logo: GraphiQL::Rails.config.logo,
       headers: GraphiQL::Rails.config.resolve_headers(self),
       query_params: GraphiQL::Rails.config.query_params,
-      header_editor_enabled: GraphiQL::Rails.config.header_editor_enabled
+      header_editor_enabled: GraphiQL::Rails.config.header_editor_enabled,
+      input_value_deprecation: GraphiQL::Rails.config.input_value_deprecation
     } %>
   </body>
 </html>

--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -7,7 +7,7 @@ module GraphiQL
       # @return [Hash<String => Proc>] Keys are headers to include in GraphQL requests, values are `->(view_context) { ... }` procs to determin values
       attr_accessor :headers
 
-      attr_accessor :query_params, :initial_query, :csrf, :title, :logo, :header_editor_enabled
+      attr_accessor :query_params, :initial_query, :csrf, :title, :logo, :header_editor_enabled, :input_value_deprecation
 
       DEFAULT_HEADERS = {
         'Content-Type' => ->(_) { 'application/json' },
@@ -17,13 +17,14 @@ module GraphiQL
         "X-CSRF-Token" => -> (view_context) { view_context.form_authenticity_token }
       }
 
-      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS)
+      def initialize(query_params: false, initial_query: nil, title: nil, logo: nil, csrf: true, headers: DEFAULT_HEADERS, input_value_deprecation: false)
         @query_params = query_params
         @headers = headers.dup
         @initial_query = initial_query
         @title = title
         @logo = logo
         @csrf = csrf
+        @input_value_deprecation = input_value_deprecation
       end
 
       # Call defined procs, add CSRF token if specified

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ You can override `GraphiQL::Rails.config` values in an initializer (eg, `config/
 - `csrf` (boolean, default `true`): include `X-CSRF-Token` in GraphiQL's HTTP requests
 - `header_editor_enabled` (boolean, default `false`): if provided, the header editor will be rendered
 - `headers` (hash, `String => Proc`): procs to fetch header values for GraphiQL's HTTP requests, in the form `(view_context) -> { ... }`. For example:
-
+- `input_value_deprecation` (boolean, default `false`): if provided, the deprecated arguments will be rendered
 
     ```ruby
     GraphiQL::Rails.config.headers['Authorization'] = -> (context) { "bearer #{context.cookies['_graphql_token']}" }


### PR DESCRIPTION
with flag toggled off:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/261381/235206626-3744f182-9330-45d7-9a07-8e88a653006f.png">


with flag toggled on:

<img width="528" alt="image" src="https://user-images.githubusercontent.com/261381/235206420-9401d230-a565-4505-ac52-0354cffe515f.png">

<img width="465" alt="image" src="https://user-images.githubusercontent.com/261381/235207228-2b10bd34-7e2b-4291-a141-05d3015fc8e3.png">

