### PR TITLE
Prevent setting nil headers

### DIFF
--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -35,7 +35,8 @@ module GraphiQL
         end
 
         all_headers.each_with_object({}) do |(key, value), memo|
-          memo[key] = value.call(view_context)
+          header_value = value.call(view_context)
+          memo[key] = header_value if header_value.present?
         end
       end
     end

--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -36,7 +36,7 @@ module GraphiQL
 
         all_headers.each_with_object({}) do |(key, value), memo|
           header_value = value.call(view_context)
-          memo[key] = header_value if header_value.present?
+          memo[key] = header_value if !header_value.nil?
         end
       end
     end

--- a/test/graphiql/rails/config_test.rb
+++ b/test/graphiql/rails/config_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class ConfigTest < ActiveSupport::TestCase
   class MockViewContext
+    attr_accessor :customer_header_value
+
     def form_authenticity_token
       "abc-123"
     end
@@ -9,6 +11,7 @@ class ConfigTest < ActiveSupport::TestCase
 
   setup do
     @config = GraphiQL::Rails::Config.new
+    @config.headers["X-Custom-Header"] = ->(view_context) { view_context.customer_header_value }
     @view_context = MockViewContext.new
   end
 
@@ -20,5 +23,15 @@ class ConfigTest < ActiveSupport::TestCase
 
   test "it adds JSON header by default" do
     assert_equal "application/json", @config.resolve_headers(@view_context)["Content-Type"]
+  end
+
+  test "when the customer header value is nil it is not added" do
+    @view_context.customer_header_value = nil
+    assert_equal @config.resolve_headers(@view_context).has_key?("X-Custom-Header"), false
+  end
+
+  test "when the customer header value is not nil it is added" do
+    @view_context.customer_header_value = "some-value"
+    assert_equal "some-value", @config.resolve_headers(@view_context)["X-Custom-Header"]
   end
 end


### PR DESCRIPTION
If the header lambda returns `nil`, the header is still set with a value of `null`.

This PR changes that and does not set headers that resolve to `nil`.