### PR TITLE
Update recommended sass gem to use, in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,12 +44,13 @@ If you're using Rails 6 in "API mode", you'll also need to do the following:
 //= link graphiql/rails/application.js
 ```
 
-Additionally, for Rails 6, you'll also need to add `sass-rails` gem to your Gemfile and add a `manifest.js` file for Sprockets 4 to work:
+Additionally, for Rails 6, you'll also need to add `dartsass-sprockets` gem to your Gemfile and add a `manifest.js` file for Sprockets 4 to work:
 ```
 --- add to `app/assets/config/manifest.js`
 //= link graphiql/rails/application.css
 //= link graphiql/rails/application.js
 ```
+Note that the `sassc-rails` gem is unmaintained and [breaks with the newer GraphiQL](https://github.com/rmosolgo/graphiql-rails/issues/106).
 See more details in [issue #13](https://github.com/rmosolgo/graphiql-rails/issues/13#issuecomment-640366886)
 
 ### Configuration


### PR DESCRIPTION
After the last [update to graphiql assets](https://github.com/rmosolgo/graphiql-rails/pull/105), asset compilation broke because the unmaintained `sassc-rails` gem doesn't support newer SASS features: https://github.com/rmosolgo/graphiql-rails/issues/106

Luckily there's a new `dartsass` library, as well as a `dartsass-sprockets` gem that acts similarly to `sassc-rails`. 

We should probably suggest these new libraries now, although I recommend removing Sprockets as a pre-req like this PR has done: https://github.com/rmosolgo/graphiql-rails/pull/101

(note that the rails team has a [`dartsass-rails`](https://github.com/rails/dartsass-rails) gem too, which isn't coupled to sprockets)