### PR TITLE
Remove Sprockets -- Updated

### DIFF
--- a/app/assets/javascripts/graphiql/rails/application.js
+++ b/app/assets/javascripts/graphiql/rails/application.js
@@ -1,5 +1,0 @@
-//= require ./react-17.0.2
-//= require ./react-dom-17.0.2
-//= require ./fetch-0.10.1
-//= require ./graphiql-2.4.0
-//= require ./graphiql_show

--- a/app/assets/stylesheets/graphiql/rails/application.css
+++ b/app/assets/stylesheets/graphiql/rails/application.css
@@ -1,7 +1,3 @@
-/*
- = require ./graphiql-2.4.0
-*/
-
 html, body, #graphiql-container {
   height: 100%;
   margin: 0;

--- a/app/views/graphiql/rails/editors/show.html.erb
+++ b/app/views/graphiql/rails/editors/show.html.erb
@@ -3,8 +3,13 @@
   <head>
     <title><%= GraphiQL::Rails.config.title || 'GraphiQL' %></title>
 
+    <%= stylesheet_link_tag("graphiql/rails/graphiql-2.4.0") %>
     <%= stylesheet_link_tag("graphiql/rails/application") %>
-    <%= javascript_include_tag("graphiql/rails/application", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/react-17.0.2", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/react-dom-17.0.2", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/fetch-0.10.1", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/graphiql-2.4.0", nonce: true )  %>
+    <%= javascript_include_tag("graphiql/rails/graphiql_show", nonce: true )  %>
   </head>
   <body>
     <%= content_tag :div, 'Loading...', id: 'graphiql-container', data: {

--- a/graphiql-rails.gemspec
+++ b/graphiql-rails.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "railties"
-  s.add_runtime_dependency "sprockets-rails"
 
   s.add_development_dependency "rails"
   s.add_development_dependency "sqlite3"

--- a/readme.md
+++ b/readme.md
@@ -31,27 +31,6 @@ end
 - `at:` is the path where GraphiQL will be served. You can access GraphiQL by visiting that path in your app.
 - `graphql_path:` is the path to the GraphQL endpoint. GraphiQL will send queries to this path.
 
-#### Note on API Mode
-
-If you're using Rails 6 in "API mode", you'll also need to do the following:
-
-1. Add `require "sprockets/railtie"` to your `application.rb`.
-
-2. Create an `app/assets/config/manifest.js` file and add the following:
-
-```
-//= link graphiql/rails/application.css
-//= link graphiql/rails/application.js
-```
-
-Additionally, for Rails 6, you'll also need to add `sass-rails` gem to your Gemfile and add a `manifest.js` file for Sprockets 4 to work:
-```
---- add to `app/assets/config/manifest.js`
-//= link graphiql/rails/application.css
-//= link graphiql/rails/application.js
-```
-See more details in [issue #13](https://github.com/rmosolgo/graphiql-rails/issues/13#issuecomment-640366886)
-
 ### Configuration
 
 You can override `GraphiQL::Rails.config` values in an initializer (eg, `config/initializers/graphiql.rb`). The configs are:

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -2,7 +2,6 @@ require File.expand_path('../boot', __FILE__)
 
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
# Summary

Closed the [original PR](https://github.com/rmosolgo/graphiql-rails/pull/101) which removes Sprockets from this gem (since Sprockets doesn't integrate with Rails 7+).  This PR is an update, using the current code from this gem. [forked repo](https://github.com/scott-knight/graphiql-rails)

## Reason
- Sprockets is retired, no longer supported, and shouldn't be used.

## Updates
1. Removed sprockets as a dependency since it doesn't do anything in Rails 7+. 
3. Moved all file references to the view, which should also satisfy the needs of older versions of Rails. 

<br/>

Works like a charm

![updated-graphiql](https://github.com/rmosolgo/graphiql-rails/assets/516548/6641e22a-2a46-446e-a72d-ef495ba109c6)
